### PR TITLE
Added ability to add fields to the request sent to TransloadIt.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -8,12 +8,12 @@ var fs = require('fs');
 var API_HOST = 'api2.transloadit.com';
 var API_PATH = '/assemblies';
 
-/** 
+/**
  * Class Client
  *
  * @param {authKey} string Transloadit API key
  * @param {authSecret} string Transloadit API secret
- * 
+ *
  * @return {Client} object
  */
 
@@ -31,7 +31,7 @@ var Client = module.exports = function(authKey, authSecret) {
 };
 
 var methods = function() {
-    /** 
+    /**
      * Public methods
      */
     this.addStream = function(name, file, type, size, stream) {
@@ -52,7 +52,13 @@ var methods = function() {
         this.addStream(file_name, file_name, _mime_type, stat.size, stream);
     };
 
-    this.send = function(params, success_cb, failure_cb) {
+    this.send = function(params, fields, success_cb, failure_cb) {
+        if (_.isFunction(fields)){
+            failure_cb = success_cb;
+            success_cb = fields;
+            fields = {};
+        }
+
         var expires_date = new Date().add({ days: 1 });
 
         if (!params.auth) { params.auth = {}; }
@@ -66,12 +72,17 @@ var methods = function() {
         var signature = hmac.digest('hex');
 
         req.setParam("params", json_params);
+        for(var key in fields){
+            if (_.isObject(fields[key]) || _.isArray(fields[key]))
+                req.setParam(key, json.stringify(fields[key]));
+            else
+                req.setParam(key, fields[key]);
+        }
         req.setParam("signature", signature);
-
         _.each(this.streams, function(value, key) {
             req.addStream(key, value.file, value.type, value.length, value.stream);
         });
-        
+
         req.send(function(err, res) {
             var body = '';
             res.on('data', function (chunk) {
@@ -81,7 +92,7 @@ var methods = function() {
             res.on('end', function() {
                 var result = JSON.parse(body);
                 // console.log('Final data: ' + JSON.stringify(result));
-        
+
                 if (result.ok) {
                     if (success_cb) {
                         success_cb(result);


### PR DESCRIPTION
Added a 'fields' parameter to the Client 'send' method, so that fields may be added to the request sent to TransloadIt. I've maintained backward compatibility by type-checking the new 'fields' parameter; when the second parameter is a function it is assumed to be 'success_cb' (as it was before this update).
