### PR TITLE
Datejs removed

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,6 @@
 var http = require('http');
 var multi = require('multiparter');
 var crypto = require('crypto');
-var datejs = require('datejs');
 var _ = require('underscore');
 var fs = require('fs');
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "engines": [ "node" ],
     "dependencies": {
         "multiparter": "0.1.4"
-        , "datejs": ""
         , "underscore": "1.2.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Removed datejs, because it was unused, and has some terrible circular prototype chains that are exposed when depended on in more than one repo.
