### PR TITLE
Handles errors in lib/client this.send

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -84,6 +84,7 @@ var methods = function() {
         });
 
         req.send(function(err, res) {
+            if(err) return failure_cb(err);
             var body = '';
             res.on('data', function (chunk) {
                 body += chunk;


### PR DESCRIPTION
In lib/client when a request is sent off with the multiparter sometimes it errors out.  This little change handles that.
