### PR TITLE
fix wrap JSON.parse into try-catch

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -64,10 +64,13 @@ var methods = function() {
 
         var onResponse = function(err, res) {
             if (err) return failure_cb(err);
+            try {
+                var result = JSON.parse(res.body);
+            } catch (e) {
+                return failure_cb(e);
+            }
             
-            var result = JSON.parse(res.body);
-            
-            if (result.ok && success_cb)
+            if (result && result.ok && success_cb)
                 return success_cb(result);
             if (failure_cb)
                 return failure_cb(result.error || "NOT OK");


### PR DESCRIPTION
You might want to wrap JSON.parse into a try-catch block for the rare cases you don't get a json back from transloadit (I got this issue a few times).
